### PR TITLE
Fix deeply nested value updates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,10 @@
     "no-undef": "off",
     "no-use-before-define": "off",
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": ["error"],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }
+    ],
     "max-lines-per-function": "off",
     "consistent-return": "off",
     "jest/no-if": "off"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,8 +35,8 @@ model Comment {
   content     String
   author      User      @relation(fields: [authorId], references: [id])
   authorId    Int
-  post        Post      @relation(fields: [postId], references: [id])
-  postId      Int
+  post        Post?      @relation(fields: [postId], references: [id])
+  postId      Int?
   repliedTo   Comment?  @relation("replies", fields: [repliedToId], references: [id])
   repliedToId Int?
   replies     Comment[] @relation("replies")

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,26 @@
 /* eslint-disable import/no-unresolved */
 // @ts-ignore unable to generate prisma client before building
-import { Prisma } from '@prisma/client';
+import { Prisma } from "@prisma/client";
 
-import get from 'lodash/get';
-import set from 'lodash/set';
+import get from "lodash/get";
+import set from "lodash/set";
 
 if (!Prisma.dmmf) {
-  throw new Error('Prisma DMMF not found, please generate Prisma client using `npx prisma generate`');
+  throw new Error(
+    "Prisma DMMF not found, please generate Prisma client using `npx prisma generate`"
+  );
 }
 
 const relationsByModel: Record<string, Prisma.DMMF.Field[]> = {};
 Prisma.dmmf.datamodel.models.forEach((model: Prisma.DMMF.Model) => {
   relationsByModel[model.name] = model.fields.filter(
-    (field) => field.kind === 'object' && field.relationName
+    (field) => field.kind === "object" && field.relationName
   );
 });
 
-export type NestedAction = Prisma.PrismaAction | 'connectOrCreate';
+export type NestedAction = Prisma.PrismaAction | "connectOrCreate";
 
-export type NestedParams = Omit<Prisma.MiddlewareParams, 'action'> & {
+export type NestedParams = Omit<Prisma.MiddlewareParams, "action"> & {
   action: NestedAction;
   scope?: NestedParams;
 };
@@ -39,18 +41,18 @@ type PromiseCallbackRef = {
 };
 
 const writeOperationsSupportingNestedWrites: NestedAction[] = [
-  'create',
-  'update',
-  'upsert',
-  'connectOrCreate',
+  "create",
+  "update",
+  "upsert",
+  "connectOrCreate",
 ];
 
 const writeOperations: NestedAction[] = [
   ...writeOperationsSupportingNestedWrites,
-  'createMany',
-  'updateMany',
-  'delete',
-  'deleteMany',
+  "createMany",
+  "updateMany",
+  "delete",
+  "deleteMany",
 ];
 
 function isWriteOperation(key: any): key is NestedAction {
@@ -85,13 +87,13 @@ function extractNestedWriteInfo(
   const model = relation.type as Prisma.ModelName;
 
   switch (params.action) {
-    case 'upsert':
+    case "upsert":
       return [
         ...extractWriteInfo(params, model, `update.${relation.name}`),
         ...extractWriteInfo(params, model, `create.${relation.name}`),
       ];
 
-    case 'create':
+    case "create":
       // nested creates use args as data instead of including a data field.
       if (params.scope) {
         return extractWriteInfo(params, model, relation.name);
@@ -99,12 +101,12 @@ function extractNestedWriteInfo(
 
       return extractWriteInfo(params, model, `data.${relation.name}`);
 
-    case 'update':
-    case 'updateMany':
-    case 'createMany':
+    case "update":
+    case "updateMany":
+    case "createMany":
       return extractWriteInfo(params, model, `data.${relation.name}`);
 
-    case 'connectOrCreate':
+    case "connectOrCreate":
       return extractWriteInfo(params, model, `create.${relation.name}`);
 
     default:
@@ -116,7 +118,7 @@ export function createNestedMiddleware<T>(
   middleware: NestedMiddleware
 ): Prisma.Middleware<T> {
   const nestedMiddleware: NestedMiddleware = async (params, next) => {
-    const relations = relationsByModel[params.model || ''] || [];
+    const relations = relationsByModel[params.model || ""] || [];
     const finalParams = params;
     const nestedWrites: {
       relationName: string;


### PR DESCRIPTION
There is a bug where modifying results that are nested within a list
result does not work, the result is always undefined.

The reason modifying results that are within a list does not work is
that the nested relation is found on each item of the list rather than
the list itself, so when we get the relation by name the result is
always `undefined`.

When a `next` function is returning a relation that is nested within a
list combine all the relation values into a single flat array. This
means middleware only has to handle flat arrays of results which makes
modifying the result before it is returned easier. If the result's
parent is needed then it is possible to go through the parent middleware
and traverse that relation; only a single depth of relation needs to be
traversed as the middleware will be called for each layer.

Add more specific tests to ensure the problem is fixed at various
depths.