### PR TITLE
feat: call middleware for nested reads

### DIFF
--- a/test/calls.test.ts
+++ b/test/calls.test.ts
@@ -15,7 +15,12 @@ type MiddlewareCall<Model extends Prisma.ModelName> = {
     | "createMany"
     | "updateMany"
     | "deleteMany"
-    | "connectOrCreate";
+    | "connectOrCreate"
+    | "findUnique"
+    | "findFirst"
+    | "findMany"
+    | "include"
+    | "select";
   argsPath: string;
   scope?: MiddlewareCall<any>;
 };
@@ -34,7 +39,7 @@ function nestedParamsFromCall<Model extends Prisma.ModelName>(
 
 describe("calls", () => {
   it("calls middleware once when there are no nested operations", async () => {
-    const middleware = jest.fn((params, next) => next(params))
+    const middleware = jest.fn((params, next) => next(params));
     const nestedMiddleware = createNestedMiddleware(middleware);
 
     const next = jest.fn((params: any) => params);
@@ -160,6 +165,38 @@ describe("calls", () => {
         },
       }),
       calls: [
+        {
+          action: "create",
+          model: "Post",
+          argsPath: "args.data.posts.create",
+        },
+      ],
+    },
+    {
+      description: "nested create and update in update",
+      rootParams: createParams("User", "update", {
+        where: { id: faker.datatype.number() },
+        data: {
+          email: faker.internet.email(),
+          profile: {
+            update: { bio: faker.lorem.paragraph() },
+          },
+          posts: {
+            create: [
+              {
+                title: faker.lorem.sentence(),
+                content: faker.lorem.paragraph(),
+              },
+            ],
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "update",
+          model: "Profile",
+          argsPath: "args.data.profile.update",
+        },
         {
           action: "create",
           model: "Post",
@@ -1040,11 +1077,709 @@ describe("calls", () => {
         },
       ],
     },
+    {
+      description: "include in findUnique",
+      rootParams: createParams("User", "findUnique", {
+        where: { id: faker.datatype.number() },
+        include: {
+          posts: true,
+        },
+      }),
+      calls: [
+        {
+          action: "include",
+          model: "Post",
+          argsPath: "args.include.posts",
+        },
+      ],
+    },
+    {
+      description: "include in findFirst",
+      rootParams: createParams("User", "findFirst", {
+        where: { id: faker.datatype.number() },
+        include: { posts: true },
+      }),
+      calls: [
+        {
+          action: "include",
+          model: "Post",
+          argsPath: "args.include.posts",
+        },
+      ],
+    },
+    {
+      description: "include in findMany",
+      rootParams: createParams("User", "findMany", {
+        where: { id: faker.datatype.number() },
+        include: { posts: true },
+      }),
+      calls: [
+        {
+          action: "include",
+          model: "Post",
+          argsPath: "args.include.posts",
+        },
+      ],
+    },
+    {
+      description: "include in create",
+      rootParams: createParams("User", "create", {
+        data: {
+          email: faker.internet.email(),
+          posts: { create: { title: faker.lorem.sentence() } },
+        },
+        include: { posts: true },
+      }),
+      calls: [
+        {
+          action: "create",
+          model: "Post",
+          argsPath: "args.data.posts.create",
+        },
+        {
+          action: "include",
+          model: "Post",
+          argsPath: "args.include.posts",
+        },
+      ],
+    },
+    {
+      description: "include in update",
+      rootParams: createParams("User", "update", {
+        where: { id: faker.datatype.number() },
+        data: {
+          email: faker.internet.email(),
+        },
+        include: { posts: true },
+      }),
+      calls: [
+        {
+          action: "include",
+          model: "Post",
+          argsPath: "args.include.posts",
+        },
+      ],
+    },
+    {
+      description: "include in upsert",
+      rootParams: createParams("User", "upsert", {
+        where: { id: faker.datatype.number() },
+        create: {
+          email: faker.internet.email(),
+        },
+        update: {
+          email: faker.internet.email(),
+        },
+        include: { posts: true },
+      }),
+      calls: [
+        {
+          action: "include",
+          model: "Post",
+          argsPath: "args.include.posts",
+        },
+      ],
+    },
+    {
+      description: "nested includes",
+      rootParams: createParams("User", "findUnique", {
+        where: { id: faker.datatype.number() },
+        include: {
+          posts: {
+            include: {
+              comments: true,
+            },
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "include",
+          model: "Post",
+          argsPath: "args.include.posts",
+        },
+        {
+          action: "include",
+          model: "Comment",
+          argsPath: "args.include.posts.include.comments",
+          scope: {
+            action: "include",
+            model: "Post",
+            argsPath: "args.include.posts",
+          },
+        },
+      ],
+    },
+    {
+      description: "deeply nested includes",
+      rootParams: createParams("User", "findUnique", {
+        where: { id: faker.datatype.number() },
+        include: {
+          posts: {
+            include: {
+              comments: {
+                include: {
+                  replies: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "include",
+          model: "Post",
+          argsPath: "args.include.posts",
+        },
+        {
+          action: "include",
+          model: "Comment",
+          argsPath: "args.include.posts.include.comments",
+          scope: {
+            action: "include",
+            model: "Post",
+            argsPath: "args.include.posts",
+          },
+        },
+        {
+          action: "include",
+          model: "Comment",
+          argsPath: "args.include.posts.include.comments.include.replies",
+
+          scope: {
+            action: "include",
+            model: "Comment",
+            argsPath: "args.include.posts.include.comments",
+
+            scope: {
+              action: "include",
+              model: "Post",
+              argsPath: "args.include.posts",
+            },
+          },
+        },
+      ],
+    },
+    {
+      description: "select in findUnique",
+      rootParams: createParams("User", "findUnique", {
+        where: { id: faker.datatype.number() },
+        select: {
+          posts: true,
+        },
+      }),
+      calls: [
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+      ],
+    },
+    {
+      description: "select in findFirst",
+      rootParams: createParams("User", "findFirst", {
+        where: { id: faker.datatype.number() },
+        select: { posts: true },
+      }),
+      calls: [
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+      ],
+    },
+    {
+      description: "select in findMany",
+      rootParams: createParams("User", "findMany", {
+        where: { id: faker.datatype.number() },
+        select: { posts: true },
+      }),
+      calls: [
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+      ],
+    },
+    {
+      description: "select in create",
+      rootParams: createParams("User", "create", {
+        data: {
+          email: faker.internet.email(),
+          posts: { create: { title: faker.lorem.sentence() } },
+        },
+        select: { posts: true },
+      }),
+      calls: [
+        {
+          action: "create",
+          model: "Post",
+          argsPath: "args.data.posts.create",
+        },
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+      ],
+    },
+    {
+      description: "select in update",
+      rootParams: createParams("User", "update", {
+        where: { id: faker.datatype.number() },
+        data: {
+          email: faker.internet.email(),
+        },
+        select: { posts: true },
+      }),
+      calls: [
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+      ],
+    },
+    {
+      description: "select in upsert",
+      rootParams: createParams("User", "upsert", {
+        where: { id: faker.datatype.number() },
+        create: {
+          email: faker.internet.email(),
+        },
+        update: {
+          email: faker.internet.email(),
+        },
+        select: { posts: true },
+      }),
+      calls: [
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+      ],
+    },
+    {
+      description: "nested selects",
+      rootParams: createParams("User", "findUnique", {
+        where: { id: faker.datatype.number() },
+        select: {
+          posts: {
+            select: {
+              comments: true,
+            },
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+        {
+          action: "select",
+          model: "Comment",
+          argsPath: "args.select.posts.select.comments",
+          scope: {
+            action: "select",
+            model: "Post",
+            argsPath: "args.select.posts",
+          },
+        },
+      ],
+    },
+    {
+      description: "deeply nested selects",
+      rootParams: createParams("User", "findUnique", {
+        where: { id: faker.datatype.number() },
+        select: {
+          posts: {
+            select: {
+              comments: {
+                select: {
+                  replies: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+        {
+          action: "select",
+          model: "Comment",
+          argsPath: "args.select.posts.select.comments",
+          scope: {
+            action: "select",
+            model: "Post",
+            argsPath: "args.select.posts",
+          },
+        },
+        {
+          action: "select",
+          model: "Comment",
+          argsPath: "args.select.posts.select.comments.select.replies",
+
+          scope: {
+            action: "select",
+            model: "Comment",
+            argsPath: "args.select.posts.select.comments",
+
+            scope: {
+              action: "select",
+              model: "Post",
+              argsPath: "args.select.posts",
+            },
+          },
+        },
+      ],
+    },
+    {
+      description: "deeply nested selects with custom fields",
+      rootParams: createParams("User", "findUnique", {
+        where: { id: faker.datatype.number() },
+        select: {
+          posts: {
+            select: {
+              title: true,
+              comments: {
+                select: {
+                  content: true,
+                  replies: {
+                    select: {
+                      content: true,
+                      createdAt: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+        {
+          action: "select",
+          model: "Comment",
+          argsPath: "args.select.posts.select.comments",
+          scope: {
+            action: "select",
+            model: "Post",
+            argsPath: "args.select.posts",
+          },
+        },
+        {
+          action: "select",
+          model: "Comment",
+          argsPath: "args.select.posts.select.comments.select.replies",
+          scope: {
+            action: "select",
+            model: "Comment",
+            argsPath: "args.select.posts.select.comments",
+            scope: {
+              action: "select",
+              model: "Post",
+              argsPath: "args.select.posts",
+            },
+          },
+        },
+      ],
+    },
+    {
+      description: "nested select in include",
+      rootParams: createParams("User", "findUnique", {
+        where: { id: faker.datatype.number() },
+        include: {
+          posts: {
+            select: {
+              comments: true,
+            },
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "include",
+          model: "Post",
+          argsPath: "args.include.posts",
+        },
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.include.posts.select",
+        },
+        {
+          action: "select",
+          model: "Comment",
+          argsPath: "args.include.posts.select.comments",
+          scope: {
+            action: "include",
+            model: "Post",
+            argsPath: "args.include.posts",
+          },
+        },
+      ],
+    },
+    {
+      description: "nested include in select",
+      rootParams: createParams("User", "findUnique", {
+        where: { id: faker.datatype.number() },
+        select: {
+          posts: {
+            include: {
+              comments: true,
+            },
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+        {
+          action: "include",
+          model: "Comment",
+          argsPath: "args.select.posts.include.comments",
+          scope: {
+            action: "select",
+            model: "Post",
+            argsPath: "args.select.posts",
+          },
+        },
+      ],
+    },
+    {
+      description: "nested select in nested include",
+      rootParams: createParams("User", "findUnique", {
+        where: { id: faker.datatype.number() },
+        include: {
+          posts: {
+            include: {
+              comments: {
+                select: {
+                  content: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "include",
+          model: "Post",
+          argsPath: "args.include.posts",
+        },
+        {
+          action: "include",
+          model: "Comment",
+          argsPath: "args.include.posts.include.comments",
+          scope: {
+            action: "include",
+            model: "Post",
+            argsPath: "args.include.posts",
+          },
+        },
+        {
+          action: "select",
+          model: "Comment",
+          argsPath: "args.include.posts.include.comments.select",
+          scope: {
+            action: "include",
+            model: "Post",
+            argsPath: "args.include.posts",
+          },
+        }
+      ],
+    },
+    {
+      description: "nested include in nested select",
+      rootParams: createParams("User", "findUnique", {
+        where: { id: faker.datatype.number() },
+        select: {
+          posts: {
+            select: {
+              comments: {
+                include: {
+                  author: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+        {
+          action: "select",
+          model: "Comment",
+          argsPath: "args.select.posts.select.comments",
+          scope: {
+            action: "select",
+            model: "Post",
+            argsPath: "args.select.posts",
+          },
+        },
+        {
+          action: "include",
+          model: "User",
+          argsPath: "args.select.posts.select.comments.include.author",
+          scope: {
+            action: "select",
+            model: "Comment",
+            argsPath: "args.select.posts.select.comments",
+            scope: {
+              action: "select",
+              model: "Post",
+              argsPath: "args.select.posts",
+            },
+          },
+        },
+      ],
+    },
+    {
+      description: "nested includes with nested create",
+      rootParams: createParams("User", "create", {
+        data: {
+          email: faker.internet.email(),
+          posts: {
+            create: {
+              title: faker.lorem.sentence(),
+              comments: {
+                create: {
+                  authorId: faker.datatype.number(),
+                  content: faker.lorem.sentence(),
+                },
+              },
+            },
+          },
+        },
+        include: {
+          posts: {
+            include: {
+              comments: true,
+            },
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "create",
+          model: "Post",
+          argsPath: "args.data.posts.create",
+        },
+        {
+          action: "create",
+          model: "Comment",
+          argsPath: "args.data.posts.create.comments.create",
+          scope: {
+            action: "create",
+            model: "Post",
+            argsPath: "args.data.posts.create",
+          },
+        },
+        {
+          action: "include",
+          model: "Post",
+          argsPath: "args.include.posts",
+        },
+        {
+          action: "include",
+          model: "Comment",
+          argsPath: "args.include.posts.include.comments",
+          scope: {
+            action: "include",
+            model: "Post",
+            argsPath: "args.include.posts",
+          },
+        },
+      ],
+    },
+    {
+      description: "nested selects with nested create",
+      rootParams: createParams("User", "create", {
+        data: {
+          email: faker.internet.email(),
+          posts: {
+            create: {
+              title: faker.lorem.sentence(),
+              comments: {
+                create: {
+                  authorId: faker.datatype.number(),
+                  content: faker.lorem.sentence(),
+                },
+              },
+            },
+          },
+        },
+        select: {
+          posts: {
+            select: {
+              comments: true,
+            },
+          },
+        },
+      }),
+      calls: [
+        {
+          action: "create",
+          model: "Post",
+          argsPath: "args.data.posts.create",
+        },
+        {
+          action: "create",
+          model: "Comment",
+          argsPath: "args.data.posts.create.comments.create",
+          scope: {
+            action: "create",
+            model: "Post",
+            argsPath: "args.data.posts.create",
+          },
+        },
+        {
+          action: "select",
+          model: "Post",
+          argsPath: "args.select.posts",
+        },
+        {
+          action: "select",
+          model: "Comment",
+          argsPath: "args.select.posts.select.comments",
+          scope: {
+            action: "select",
+            model: "Post",
+            argsPath: "args.select.posts",
+          },
+        },
+      ],
+    },
   ])("calls middleware with $description", async ({ rootParams, calls }) => {
     const middleware = jest.fn((params, next) => next(params));
     const nestedMiddleware = createNestedMiddleware(middleware);
 
-    const next = (params: any) => params;
+    const next = (_: any) => Promise.resolve({});
     await nestedMiddleware(rootParams, next);
 
     expect(middleware).toHaveBeenCalledTimes(calls.length + 1);

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -65,6 +65,424 @@ describe("results", () => {
     });
   });
 
+  it("allows middleware to modify included results through include action", async () => {
+    const nestedMiddleware = createNestedMiddleware(async (params, next) => {
+      const result = await next(params);
+      if (!result) return;
+
+      if (params.action === "include" && params.model === "Post") {
+        return addReturnedDate(result);
+      }
+
+      return result;
+    });
+
+    const next = jest.fn((params) =>
+      Promise.resolve({
+        id: faker.datatype.number(),
+        email: params.args.data.email,
+        posts: [
+          {
+            id: faker.datatype.number(),
+            title: params.args.data.posts.create.title,
+          },
+        ],
+      })
+    );
+    const params = createParams("User", "create", {
+      data: {
+        email: faker.internet.email(),
+        posts: { create: { title: faker.lorem.sentence() } },
+      },
+      include: {
+        posts: true,
+      },
+    });
+    const result = await nestedMiddleware(params, next);
+
+    expect(result).toEqual({
+      id: expect.any(Number),
+      email: params.args.data.email,
+      posts: [
+        {
+          id: expect.any(Number),
+          title: params.args.data.posts.create.title,
+          returned: expect.any(Date),
+        },
+      ],
+    });
+  });
+
+  it("allows middleware to modify deeply included results through include action", async () => {
+    const nestedMiddleware = createNestedMiddleware(async (params, next) => {
+      const result = await next(params);
+      if (!result) return;
+
+      if (params.action === "include" && params.model === "Comment") {
+        return addReturnedDate(result);
+      }
+
+      return result;
+    });
+
+    const next = jest.fn((params) =>
+      Promise.resolve({
+        id: faker.datatype.number(),
+        email: params.args.data.email,
+        posts: [
+          {
+            id: faker.datatype.number(),
+            title: params.args.data.posts.create.title,
+            comments: [
+              {
+                id: faker.datatype.number(),
+                content: faker.lorem.sentence(),
+                replies: [
+                  {
+                    id: faker.datatype.number(),
+                    content: faker.lorem.sentence(),
+                  },
+                  {
+                    id: faker.datatype.number(),
+                    content: faker.lorem.sentence(),
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    );
+    const params = createParams("User", "create", {
+      data: {
+        email: faker.internet.email(),
+        posts: { create: { title: faker.lorem.sentence() } },
+      },
+      include: {
+        posts: {
+          include: {
+            comments: {
+              include: {
+                replies: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    const result = await nestedMiddleware(params, next);
+
+    expect(result).toEqual({
+      id: expect.any(Number),
+      email: params.args.data.email,
+      posts: [
+        {
+          id: expect.any(Number),
+          title: params.args.data.posts.create.title,
+          comments: [
+            {
+              id: expect.any(Number),
+              content: expect.any(String),
+              returned: expect.any(Date),
+              replies: [
+                {
+                  id: expect.any(Number),
+                  content: expect.any(String),
+                  returned: expect.any(Date),
+                },
+                {
+                  id: expect.any(Number),
+                  content: expect.any(String),
+                  returned: expect.any(Date),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("allows middleware to modify selected results through select action", async () => {
+    const nestedMiddleware = createNestedMiddleware(async (params, next) => {
+      const result = await next(params);
+      if (!result) return;
+
+      if (params.action === "select" && params.model === "Post") {
+        return addReturnedDate(result);
+      }
+
+      return result;
+    });
+
+    const next = jest.fn((params) =>
+      Promise.resolve({
+        id: faker.datatype.number(),
+        email: params.args.data.email,
+        posts: [
+          {
+            id: faker.datatype.number(),
+            title: params.args.data.posts.create.title,
+          },
+        ],
+      })
+    );
+    const params = createParams("User", "create", {
+      data: {
+        email: faker.internet.email(),
+        posts: { create: { title: faker.lorem.sentence() } },
+      },
+      select: {
+        posts: true,
+      },
+    });
+    const result = await nestedMiddleware(params, next);
+
+    expect(result).toEqual({
+      id: expect.any(Number),
+      email: params.args.data.email,
+      posts: [
+        {
+          id: expect.any(Number),
+          title: params.args.data.posts.create.title,
+          returned: expect.any(Date),
+        },
+      ],
+    });
+  });
+
+  it("allows middleware to modify deeply selected results through select action", async () => {
+    const nestedMiddleware = createNestedMiddleware(async (params, next) => {
+      const result = await next(params);
+      if (!result) return;
+
+      if (params.action === "select" && params.model === "Comment") {
+        return addReturnedDate(result);
+      }
+
+      return result;
+    });
+
+    const next = jest.fn((params) =>
+      Promise.resolve({
+        id: faker.datatype.number(),
+        email: params.args.data.email,
+        posts: [
+          {
+            id: faker.datatype.number(),
+            title: params.args.data.posts.create.title,
+            comments: [
+              {
+                id: faker.datatype.number(),
+                content: faker.lorem.sentence(),
+                replies: [
+                  {
+                    id: faker.datatype.number(),
+                    content: faker.lorem.sentence(),
+                  },
+                  {
+                    id: faker.datatype.number(),
+                    content: faker.lorem.sentence(),
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    );
+    const params = createParams("User", "create", {
+      data: {
+        email: faker.internet.email(),
+        posts: { create: { title: faker.lorem.sentence() } },
+      },
+      include: {
+        posts: {
+          select: {
+            comments: {
+              select: {
+                replies: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    const result = await nestedMiddleware(params, next);
+
+    expect(result).toEqual({
+      id: expect.any(Number),
+      email: params.args.data.email,
+      posts: [
+        {
+          id: expect.any(Number),
+          title: params.args.data.posts.create.title,
+          comments: [
+            {
+              id: expect.any(Number),
+              content: expect.any(String),
+              returned: expect.any(Date),
+              replies: [
+                {
+                  id: expect.any(Number),
+                  content: expect.any(String),
+                  returned: expect.any(Date),
+                },
+                {
+                  id: expect.any(Number),
+                  content: expect.any(String),
+                  returned: expect.any(Date),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+  
+  it('allows middleware to modify selected in nested include through select action', async () => {
+    const nestedMiddleware = createNestedMiddleware(async (params, next) => {
+      const result = await next(params);
+      if (!result) return;
+
+      if (params.action === 'select' && params.model === 'Comment') {
+        return addReturnedDate(result);
+      }
+
+      return result;
+    });
+       
+    const next = jest.fn((params) => Promise.resolve({
+      id: faker.datatype.number(),
+      email: params.args.data.email,
+      posts: [
+        {
+          id: faker.datatype.number(),
+          title: params.args.data.posts.create.title,
+          comments: [
+            {
+              id: faker.datatype.number(),
+              content: faker.lorem.sentence(),
+            },
+          ],
+        },
+      ],
+    }));
+    const params = createParams('User', 'create', {
+      data: {
+        email: faker.internet.email(),
+        posts: { create: { title: faker.lorem.sentence() } },
+      },
+      include: {
+        posts: {
+          select: {
+            comments: true
+          },
+        },
+      },
+    });
+    const result = await nestedMiddleware(params, next);
+
+    expect(result).toEqual({
+      id: expect.any(Number),
+      email: params.args.data.email,
+      posts: [
+        {
+          id: expect.any(Number),
+          title: params.args.data.posts.create.title,
+          comments: [
+            {
+              id: expect.any(Number),
+              content: expect.any(String),
+              returned: expect.any(Date),
+            },
+          ],
+        },
+      ],
+    });
+  });
+  
+  it('allows middleware to modify deeply included results in nested select through include action', async () => {
+    const nestedMiddleware = createNestedMiddleware(async (params, next) => {
+      const result = await next(params);
+      if (!result) return;
+
+      if (params.action === 'include' && params.model === 'Comment') {
+        return addReturnedDate(result);
+      }
+
+      return result;
+    });
+
+    const next = jest.fn((params) => Promise.resolve({
+      id: faker.datatype.number(),
+      email: params.args.data.email,
+
+      posts: [
+        {
+          id: faker.datatype.number(),
+          title: params.args.data.posts.create.title,
+          comments: [
+            {
+              id: faker.datatype.number(),
+              content: faker.lorem.sentence(),
+               replies: [
+                {
+                  id: faker.datatype.number(),
+                  content: faker.lorem.sentence(),
+                },
+               ]
+            },
+          ],
+        },
+      ],
+    }));
+    const params = createParams('User', 'create', {
+      data: {
+        email: faker.internet.email(),
+        posts: { create: { title: faker.lorem.sentence() } },
+      },
+      include: {
+        posts: {
+          select: {
+            comments: {
+              include: {
+                replies: true
+              }
+            }
+          },
+        },
+      },
+
+    });
+    const result = await nestedMiddleware(params, next);
+    
+    expect(result).toEqual({
+      id: expect.any(Number),
+      email: params.args.data.email,
+      posts: [
+        {
+          id: expect.any(Number),
+          title: params.args.data.posts.create.title,
+          comments: [
+            {
+              id: expect.any(Number),
+              content: expect.any(String),
+              replies: [
+                {
+                  id: expect.any(Number),
+                  content: expect.any(String),
+                  returned: expect.any(Date),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it("allows middleware to modify nested results", async () => {
     const nestedMiddleware = createNestedMiddleware(async (params, next) => {
       const result = await next(params);

--- a/test/utils/createParams.ts
+++ b/test/utils/createParams.ts
@@ -8,9 +8,31 @@ type DelegateByModel<Model extends Prisma.ModelName> = Model extends "User"
   ? Prisma.ProfileDelegate<undefined>
   : never;
 
+type SelectByModel<Model extends Prisma.ModelName> = Model extends "User"
+  ? Prisma.UserSelect
+  : Model extends "Post"
+  ? Prisma.PostSelect
+  : Model extends "Profile"
+  ? Prisma.ProfileSelect
+  : never;
+
+type IncludeByModel<Model extends Prisma.ModelName> = Model extends "User"
+  ? Prisma.UserInclude
+  : Model extends "Post"
+  ? Prisma.PostInclude
+  : Model extends "Profile"
+  ? Prisma.ProfileInclude
+  : never;
+
+type ActionByModel<Model extends Prisma.ModelName> =
+  | keyof DelegateByModel<Model>
+  | "connectOrCreate"
+  | "select"
+  | "include";
+
 type ArgsByAction<
   Model extends Prisma.ModelName,
-  Action extends keyof DelegateByModel<Model> | "connectOrCreate"
+  Action extends ActionByModel<Model>
 > = Action extends "create"
   ? Parameters<DelegateByModel<Model>["create"]>[0]
   : Action extends "update"
@@ -23,11 +45,21 @@ type ArgsByAction<
   ? Parameters<DelegateByModel<Model>["deleteMany"]>[0]
   : Action extends "updateMany"
   ? Parameters<DelegateByModel<Model>["updateMany"]>[0]
+  : Action extends "findUnique"
+  ? Parameters<DelegateByModel<Model>["findUnique"]>[0]
+  : Action extends "findFirst"
+  ? Parameters<DelegateByModel<Model>["findFirst"]>[0]
+  : Action extends "findMany"
+  ? Parameters<DelegateByModel<Model>["findMany"]>[0]
   : Action extends "connectOrCreate"
   ? {
       where: Parameters<DelegateByModel<Model>["findUnique"]>[0];
       create: Parameters<DelegateByModel<Model>["create"]>[0];
     }
+  : Action extends "select"
+  ? SelectByModel<Model>
+  : Action extends "include"
+  ? IncludeByModel<Model>
   : never;
 
 /**
@@ -36,9 +68,7 @@ type ArgsByAction<
  */
 export const createParams = <
   Model extends Prisma.ModelName,
-  Action extends keyof DelegateByModel<Model> | "connectOrCreate" =
-    | keyof DelegateByModel<Model>
-    | "connectOrCreate"
+  Action extends ActionByModel<Model> = ActionByModel<Model>
 >(
   model: Model,
   action: Action,


### PR DESCRIPTION
closes #2 

Call passed middleware function for each nested `include` or `select`
found in params, mark the `action` in these cases as one of two new
options "include" or "select".

It is not possible to mimic more typical "findFirst" or "findMany"
actions rather than introducing the new actions because we do not have
enough information to construct valid "where" clauses. Without
being able to construct valid params for a particular action it is safer
to add a new action type.