### PR TITLE
Fix json null types

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3.7'
 services:
   postgres:
     image: "postgres:latest"
-    container_name: further-postgres
     hostname: postgres
     user: postgres
     restart: always

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,4 +49,5 @@ model Profile {
   age    Int?
   user   User    @relation(fields: [userId], references: [id])
   userId Int     @unique
+  meta   Json?
 }

--- a/src/lib/utils/cloneParams.ts
+++ b/src/lib/utils/cloneParams.ts
@@ -1,0 +1,26 @@
+import { Prisma } from "@prisma/client";
+import { cloneDeep, cloneDeepWith } from "lodash";
+
+import { NestedParams } from "../types";
+
+// Prisma v4 requires that instances of Prisma.NullTypes are not cloned,
+// otherwise it will parse them as 'undefined' and the operation will fail.
+function passThroughNullTypes(value: any) {
+  if (
+    value instanceof Prisma.NullTypes.DbNull ||
+    value instanceof Prisma.NullTypes.JsonNull ||
+    value instanceof Prisma.NullTypes.AnyNull
+  ) {
+    return value;
+  }
+}
+
+export function cloneParams(params: NestedParams) {
+  // only handle null types if they are present, Prisma versions lower than v4
+  // do not have them and we can clone the string values as usual
+  if (Prisma.NullTypes) {
+    return cloneDeepWith(params, passThroughNullTypes);
+  }
+
+  return cloneDeep(params);
+}

--- a/src/lib/utils/execution.ts
+++ b/src/lib/utils/execution.ts
@@ -1,6 +1,5 @@
 import { DeferredPromise } from "@open-draft/deferred-promise";
 import { omit } from "lodash";
-import cloneDeep from "lodash/cloneDeep";
 
 import {
   MiddlewareCall,
@@ -8,6 +7,7 @@ import {
   NestedParams,
   Target,
 } from "../types";
+import { cloneParams } from "./cloneParams";
 
 export async function executeMiddleware(
   middleware: NestedMiddleware,
@@ -19,7 +19,7 @@ export async function executeMiddleware(
   >();
   const nextPromise = new DeferredPromise<any>();
 
-  const result = middleware(cloneDeep(params), (updatedParams) => {
+  const result = middleware(cloneParams(params), (updatedParams) => {
     paramsUpdatedPromise.resolve(updatedParams);
     return nextPromise;
   }).catch((e) => {

--- a/src/lib/utils/params.ts
+++ b/src/lib/utils/params.ts
@@ -2,7 +2,6 @@ import set from "lodash/set";
 import get from "lodash/get";
 import unset from "lodash/unset";
 import merge from "lodash/merge";
-import cloneDeep from "lodash/cloneDeep";
 import { omit } from "lodash";
 
 import {
@@ -32,6 +31,7 @@ import {
   toOneRelationNonListActions,
 } from "./actions";
 import { fieldsByWriteAction } from "./extractNestedActions";
+import { cloneParams } from "./cloneParams";
 
 function addWriteArgsToParams(
   params: NestedParams,
@@ -159,7 +159,7 @@ export function buildParamsFromCalls(
   calls: MiddlewareCall[],
   parentParams: NestedParams
 ) {
-  const finalParams = cloneDeep(parentParams);
+  const finalParams = cloneParams(parentParams);
 
   // calls should update the parent calls updated params
 

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -1,4 +1,4 @@
-import { Post, PrismaClient, User } from "@prisma/client";
+import { Post, Prisma, PrismaClient, User } from "@prisma/client";
 import faker from "faker";
 
 import { createNestedMiddleware } from "../../src";
@@ -131,6 +131,26 @@ describe("smoke", () => {
         },
       });
       expect(updatedComment).not.toBeNull();
+
+      // supports Json null values
+      await testClient.profile.create({
+        data: {
+          userId: secondUser.id,
+          meta: Prisma.DbNull,
+        },
+      });
+
+      const profile = await testClient.profile.findFirst({
+        where: {
+          OR: [
+            { meta: { equals: Prisma.AnyNull } },
+            { meta: { equals: Prisma.DbNull } },
+            { meta: { equals: Prisma.JsonNull } },
+          ],
+        },
+      });
+      expect(profile).not.toBeNull();
+      expect(profile!.meta).toBe(null);
     });
   });
 });


### PR DESCRIPTION
closes #18 

Prisma NullTypes are used as the null value for Json fields. When using
a NullType in a query the instance of the NullType must remain the same
or Prisma is unable to parse the value correctly, replacing it with
undefined.

Lodash cloneDeep causes these NullTypes to be new instances and so
params that use them have unexpected undefined values, causing errors.

When the Prisma client has NullTypes, which is true for v4, clone params
but pass through the instances of Prisma.JsonNull, Prisma.DbNull and
Prisma.AnyNull so that they are not replaced with undefined.

Prisma client v3 uses strings for these null types so cloneDeep works as
is in that case.