### PR TITLE
fix: groupBy not included in NestedAction type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ import { DeferredPromise } from "@open-draft/deferred-promise";
 export type Modifier = "is" | "isNot" | "some" | "none" | "every";
 export type LogicalOperator = "AND" | "OR" | "NOT";
 
+export type MissingPrismaAction = "groupBy";
 export type NestedQueryAction = "where";
 export type NestedReadAction = "include" | "select";
 export type NestedWriteAction =
@@ -20,6 +21,7 @@ export type NestedWriteAction =
 
 export type NestedAction =
   | Prisma.PrismaAction
+  | MissingPrismaAction
   | NestedWriteAction
   | NestedReadAction
   | NestedQueryAction;

--- a/test/unit/calls.test.ts
+++ b/test/unit/calls.test.ts
@@ -23,7 +23,8 @@ type MiddlewareCall<Model extends Prisma.ModelName> = {
     | "findMany"
     | "include"
     | "select"
-    | "where";
+    | "where"
+    | "groupBy";
   argsPath: string;
   scope?: MiddlewareCall<any>;
   relations: {
@@ -99,6 +100,13 @@ describe("calls", () => {
     {
       description: "aggregate",
       rootParams: createParams("User", "aggregate", {}),
+    },
+    {
+      description: "groupBy",
+      rootParams: createParams("User", "groupBy", {
+        by: ["email"],
+        orderBy: { email: "asc" },
+      })
     },
     {
       description: "nested create in create",
@@ -4044,6 +4052,32 @@ describe("calls", () => {
                 },
               },
             },
+          },
+        },
+      ],
+    },
+    {
+      description: "where in groupBy",
+      rootParams: createParams("User", "groupBy", {
+        by: ["id"],
+        orderBy: { id: "asc" },
+        where: {
+          posts: {
+            some: {
+              title: "foo",
+            },
+          },
+        },
+      }),
+      nestedCalls: [
+        {
+          action: "where",
+          model: "Post",
+          argsPath: "args.where.posts.some",
+          modifier: "some",
+          relations: {
+            to: getModelRelation("User", "posts"),
+            from: getModelRelation("Post", "author"),
           },
         },
       ],

--- a/test/unit/helpers/createParams.ts
+++ b/test/unit/helpers/createParams.ts
@@ -64,6 +64,8 @@ type ArgsByAction<
   ? Parameters<DelegateByModel<Model>["count"]>[0]
   : Action extends "aggregate"
   ? Parameters<DelegateByModel<Model>["aggregate"]>[0]
+  : Action extends "groupBy"
+  ? Parameters<DelegateByModel<Model>["groupBy"]>[0]
   : Action extends "connectOrCreate"
   ? {
       where: Parameters<DelegateByModel<Model>["findUnique"]>[0];


### PR DESCRIPTION
Prisma client does not include groupBy in the Prisma.PrismaAction types. This appears to be an omission because middleware is called with the action set to 'groupBy'.

Include it in NestedAction types while we wait for it to be added to Prisma.PrismaAction.