### PR TITLE
feat: avoid multiple types of select calls

### DIFF
--- a/src/lib/utils/extractNestedActions.ts
+++ b/src/lib/utils/extractNestedActions.ts
@@ -443,60 +443,6 @@ export function extractRelationReadActions(
           )
         );
       }
-
-      // push select nested in an include
-      if (action === "include" && arg.select) {
-        const nestedSelectActionInfo = {
-          params: {
-            model,
-            action: "select" as const,
-            args: arg.select,
-            runInTransaction,
-            dataPath: [],
-            scope: {
-              parentParams: readActionInfo.params,
-              relations: readActionInfo.params.scope.relations,
-            },
-          },
-          target: {
-            field: "include" as const,
-            action: "select" as const,
-            relationName: relation.name,
-            parentTarget,
-          },
-        };
-
-        nestedActions.push(nestedSelectActionInfo);
-
-        if (nestedSelectActionInfo.params.args?.where) {
-          const whereActionInfo = {
-            target: {
-              action: "where" as const,
-              relationName: relation.name,
-              readAction: "select" as const,
-              parentTarget: nestedSelectActionInfo.target,
-            },
-            params: {
-              model: nestedSelectActionInfo.params.model,
-              action: "where" as const,
-              args: nestedSelectActionInfo.params.args.where,
-              runInTransaction,
-              dataPath: [],
-              scope: {
-                parentParams: nestedSelectActionInfo.params,
-                relations: nestedSelectActionInfo.params.scope.relations,
-              },
-            },
-          };
-          nestedActions.push(whereActionInfo);
-          nestedActions.push(
-            ...extractRelationWhereActions(
-              whereActionInfo.params,
-              whereActionInfo.target
-            )
-          );
-        }
-      }
     });
   });
 

--- a/src/lib/utils/targets.ts
+++ b/src/lib/utils/targets.ts
@@ -34,9 +34,7 @@ export function buildOperationsPath(
 }
 
 export function buildQueryTargetPath(target: QueryTarget): string[] {
-  const path = target.parentTarget
-    ? buildTargetPath(target.parentTarget)
-    : [];
+  const path = target.parentTarget ? buildTargetPath(target.parentTarget) : [];
 
   if (!target.relationName) {
     return [...path, target.action];

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -152,28 +152,28 @@ describe("smoke", () => {
     });
   });
 
-  describe('groupBy', () => {
+  describe("groupBy", () => {
     beforeAll(() => {
       testClient = new PrismaClient();
       testClient.$use(
         createNestedMiddleware((params, next) => {
-          if (params.action !== 'groupBy') {
-            throw new Error('expected groupBy action')
+          if (params.action !== "groupBy") {
+            throw new Error("expected groupBy action");
           }
           return next(params);
         })
       );
     });
 
-    it('calls middleware with groupBy action', async () => {
+    it("calls middleware with groupBy action", async () => {
       await expect(testClient.comment.findMany()).rejects.toThrowError(
-        'expected groupBy action'
+        "expected groupBy action"
       );
 
       const groupBy = await testClient.comment.groupBy({
-        by: ['authorId'],
+        by: ["authorId"],
         orderBy: {
-          authorId: 'asc',
+          authorId: "asc",
         },
       });
 

--- a/test/unit/actions.test.ts
+++ b/test/unit/actions.test.ts
@@ -3125,37 +3125,5 @@ describe("actions", () => {
         set(params, "args.data.profile", { delete: false })
       );
     });
-
-    it("replaces existing include with select changed to include", async () => {
-      const nestedMiddleware = createNestedMiddleware((params, next) => {
-        if (params.action === "select") {
-          return next({
-            ...params,
-            action: "include",
-          });
-        }
-
-        return next(params);
-      });
-
-      const next = jest.fn((_: any) => Promise.resolve(null));
-      const params = createParams("User", "findUnique", {
-        where: { id: faker.datatype.number() },
-        include: {
-          posts: {
-            select: { deleted: true },
-            include: { author: true },
-          },
-        },
-      });
-
-      await nestedMiddleware(params, next);
-
-      expect(next).toHaveBeenCalledWith(
-        set(params, "args.include.posts", {
-          include: { deleted: true },
-        })
-      );
-    });
   });
 });

--- a/test/unit/calls.test.ts
+++ b/test/unit/calls.test.ts
@@ -106,7 +106,7 @@ describe("calls", () => {
       rootParams: createParams("User", "groupBy", {
         by: ["email"],
         orderBy: { email: "asc" },
-      })
+      }),
     },
     {
       description: "nested create in create",
@@ -2385,24 +2385,6 @@ describe("calls", () => {
         },
         {
           action: "select",
-          model: "Post",
-          argsPath: "args.include.posts.select",
-          relations: {
-            to: getModelRelation("User", "posts"),
-            from: getModelRelation("Post", "author"),
-          },
-          scope: {
-            action: "include",
-            model: "Post",
-            argsPath: "args.include.posts",
-            relations: {
-              to: getModelRelation("User", "posts"),
-              from: getModelRelation("Post", "author"),
-            },
-          },
-        },
-        {
-          action: "select",
           model: "Comment",
           argsPath: "args.include.posts.select.comments",
           relations: {
@@ -2504,33 +2486,6 @@ describe("calls", () => {
             relations: {
               to: getModelRelation("User", "posts"),
               from: getModelRelation("Post", "author"),
-            },
-          },
-        },
-        {
-          action: "select",
-          model: "Comment",
-          argsPath: "args.include.posts.include.comments.select",
-          relations: {
-            to: getModelRelation("Post", "comments"),
-            from: getModelRelation("Comment", "post"),
-          },
-          scope: {
-            action: "include",
-            model: "Comment",
-            argsPath: "args.include.posts.include.comments",
-            relations: {
-              to: getModelRelation("Post", "comments"),
-              from: getModelRelation("Comment", "post"),
-            },
-            scope: {
-              action: "include",
-              model: "Post",
-              argsPath: "args.include.posts",
-              relations: {
-                to: getModelRelation("User", "posts"),
-                from: getModelRelation("Post", "author"),
-              },
             },
           },
         },
@@ -3635,24 +3590,6 @@ describe("calls", () => {
           relations: {
             to: getModelRelation("User", "posts"),
             from: getModelRelation("Post", "author"),
-          },
-        },
-        {
-          action: "select",
-          model: "Post",
-          argsPath: "args.include.posts.select",
-          relations: {
-            to: getModelRelation("User", "posts"),
-            from: getModelRelation("Post", "author"),
-          },
-          scope: {
-            action: "include",
-            model: "Post",
-            argsPath: "args.include.posts",
-            relations: {
-              to: getModelRelation("User", "posts"),
-              from: getModelRelation("Post", "author"),
-            },
           },
         },
         {


### PR DESCRIPTION
Currently there are two scenarios when a select action type is found:
- When an include has a select within it
- When a select has a relation in it

This means that there is a situation where it is not possible to reason about what to do with a select because the two scenarios look the same based on the available information; both have the include action as the parent.

BREAKING CHANGE: remove the calls for include selects

Middleware that relied on calls with the "select" action for select objects within an include will no longer be able to use that call. Instead use the parent "include" action to modify the selected fields, or use the "select" action for the relation within that select object.